### PR TITLE
Added max-width to character images so they don't overlap eachother

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -120,7 +120,7 @@ const App = () => {
               .map((id, i) => (
                 <div style={{ width: '20%', textAlign: 'center', marginTop: '1em' }} key={i}>{
                   id && <img key={i} alt="" src={purl + `/portraits/${id}.png`}
-                    style={{cursor: "pointer"}}
+                    style={{cursor: "pointer", maxWidth:"100%"}}
                     onClick={()=> window.open(OPTCDB_URL + id, "_blank")}
                   />
                 }</div>


### PR DESCRIPTION
Easily noticeable with the dev console open, images overlap each other on lower screen width.
Added a 100% max-width so that doesn't happen.
![1617397242_mspaint](https://user-images.githubusercontent.com/28060941/113453888-42b87980-9407-11eb-8987-0b3c4d85d3f3.png)
